### PR TITLE
Add a splitMessage conf option and corresponding splitting routine 

### DIFF
--- a/config.py
+++ b/config.py
@@ -34,13 +34,16 @@ def configure(advanced):
     # user or not.  You should effect your configuration by manipulating the
     # registry as appropriate.
     from supybot.questions import expect, anything, something, yn
-    conf.registerPlugin('QuranFinder', True)
-
+    QuranFinder = conf.registerPlugin('QuranFinder', True)
+    if yn("""Split long verses?""", default=True):
+        QuranFinder.splitMessages.setValue(True)
+    else:
+        QuranFinder.splitMessages.setValue(False)
 
 QuranFinder = conf.registerPlugin('QuranFinder')
 # This is where your configuration variables (if any) should go.  For example:
-# conf.registerGlobalValue(QuranFinder, 'someConfigVariableName',
-#     registry.Boolean(False, _("""Help for someConfigVariableName.""")))
+conf.registerGlobalValue(QuranFinder, 'splitMessages',
+    registry.Boolean(True, _("""Set to split long verses.""")))
 
 
 # vim:set shiftwidth=4 tabstop=4 expandtab textwidth=79:

--- a/plugin.py
+++ b/plugin.py
@@ -98,10 +98,16 @@ class QuranFinder(callbacks.Plugin):
         except (KeyError, TypeError) as e: #TypeError incase requesting a audio version. The json would contain a list so qdata would raise a TypeError
             irc.error("Wrong translation code or broken API.") 
             return
-         
 
-
-        irc.reply(str(data.SurahNumber) + "," + str(data.ayahNumber) + ": " + data.ayahText)
+        if self.registryValue('splitMessages'):
+            ircMsgBytes = (str(data.SurahNumber) + "," + str(data.ayahNumber) + ": " + data.ayahText).encode('utf-8')
+            while len(ircMsgBytes) > 350:
+                splitPoint = ircMsgBytes[0:351].rfind(' '.encode('utf-8'))
+                irc.reply(ircMsgBytes[0:splitPoint].decode('utf-8').strip())
+                ircMsgBytes = ircMsgBytes[splitPoint:]
+            irc.reply(ircMsgBytes.decode('utf-8').strip())
+        else:
+            irc.reply(str(data.SurahNumber) + "," + str(data.ayahNumber) + ": " + data.ayahText)
 
     quran = wrap(quran, ["int", "int", optional("something")])
 


### PR DESCRIPTION
The Limnoria support for Arabic seems to be broken so here is a workaround for that. It splits long verses to fit in the irc message length limitations already in the plugin and hopefully does better job at it than the Limnoria implementation.
