### PR TITLE
Add conf option to set the length to which verses are split to

### DIFF
--- a/config.py
+++ b/config.py
@@ -44,6 +44,8 @@ QuranFinder = conf.registerPlugin('QuranFinder')
 # This is where your configuration variables (if any) should go.  For example:
 conf.registerGlobalValue(QuranFinder, 'splitMessages',
     registry.Boolean(True, _("""Set to split long verses.""")))
+conf.registerGlobalValue(QuranFinder, 'splitMessagesAt',
+    registry.PositiveInteger(350, _("""Set where to split long verses.""")))
 
 
 # vim:set shiftwidth=4 tabstop=4 expandtab textwidth=79:

--- a/plugin.py
+++ b/plugin.py
@@ -99,10 +99,11 @@ class QuranFinder(callbacks.Plugin):
             irc.error("Wrong translation code or broken API.") 
             return
 
+        ircMsgLen = self.registryValue('splitMessagesAt')
         if self.registryValue('splitMessages'):
             ircMsgBytes = (str(data.SurahNumber) + "," + str(data.ayahNumber) + ": " + data.ayahText).encode('utf-8')
-            while len(ircMsgBytes) > 350:
-                splitPoint = ircMsgBytes[0:351].rfind(' '.encode('utf-8'))
+            while len(ircMsgBytes) > ircMsgLen:
+                splitPoint = ircMsgBytes[0:ircMsgLen + 1].rfind(' '.encode('utf-8'))
                 irc.reply(ircMsgBytes[0:splitPoint].decode('utf-8').strip())
                 ircMsgBytes = ircMsgBytes[splitPoint:]
             irc.reply(ircMsgBytes.decode('utf-8').strip())


### PR DESCRIPTION
Maybe better put also the message length to split verses to as a conf parameter. The actual maximum length depends on the size of the message headers and we are not calculating that, instead we just choose a constant value that is arbitrary but sufficient in practice. 
